### PR TITLE
Set `useUnifiedTopology: true` option on connect to mongo

### DIFF
--- a/primus/index.js
+++ b/primus/index.js
@@ -26,7 +26,11 @@ global.primus = Primus.createServer(function connection(spark) {
 
 
 // Connect to the db
-MongoClient.connect(mongodbUrl, {useNewUrlParser: true}, function (err, client) {
+let opts = {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+};
+MongoClient.connect(mongodbUrl, opts, function (err, client) {
     if (err) {
         log.error("MONGO_URL not set on Primus");
         throw err;


### PR DESCRIPTION
fixed to connect error and removed this warning.

```
primus      | (node:18) [MONGODB DRIVER] Warning: Current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
```
